### PR TITLE
CC-546 Suite isn't working with mysql

### DIFF
--- a/src/Spryker/Zed/EventBehavior/Persistence/Propel/Schema/spy_event_behavior.schema.xml
+++ b/src/Spryker/Zed/EventBehavior/Persistence/Propel/Schema/spy_event_behavior.schema.xml
@@ -3,7 +3,7 @@
 
     <table name="spy_event_behavior_entity_change">
         <column name="id_event_behavior_entity_change" type="BIGINT" autoIncrement="true" primaryKey="true"/>
-        <column name="data" type="VARCHAR"/>
+        <column name="data" type="LONGVARCHAR"/>
         <column name="process_id" type="VARCHAR"/>
         <behavior name="timestampable">
             <parameter name="disable_updated_at" value="true" />


### PR DESCRIPTION
- Developer(s): @kraal-spryker

- Ticket: https://spryker.atlassian.net/browse/CC-546

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release-app.herokuapp.com/release-groups/view/483


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   EventBehavior         | minor                 |                       |

#### Release Notes



-----------------------------------------

#### Module EventBehavior

_**Minor:** Added functionality in a backwards-compatible manner_

Def of done (by responsible developer):
- [ ] All changes are backward-compatible. Outdated code is marked as deprecated.
- [ ] New and changed facade methods covered by functional tests. / Has nothing to test.
- [ ] New and changed complex business logic is covered by unit or integration tests. / Has nothing to test.

##### Change log

Improvements

Change data type of column data from varchar to text on table spy_event_behavior_entity_change


