### PR TITLE
CC-3421 CMS block not assigned to a store is displayed on the store CMS page

### DIFF
--- a/src/Spryker/Zed/EventBehavior/Business/Model/TriggerManager.php
+++ b/src/Spryker/Zed/EventBehavior/Business/Model/TriggerManager.php
@@ -126,7 +126,9 @@ class TriggerManager implements TriggerManagerInterface
             $eventEntityTransfer->setName($data[EventBehavior::EVENT_CHANGE_ENTITY_NAME]);
             $eventEntityTransfer->setId($data[EventBehavior::EVENT_CHANGE_ENTITY_ID]);
             $eventEntityTransfer->setForeignKeys($data[EventBehavior::EVENT_CHANGE_ENTITY_FOREIGN_KEYS]);
-            $eventEntityTransfer->setOriginalValues($data[EventBehavior::EVENT_CHANGE_ENTITY_ORIGINAL_VALUES]);
+            if (isset($data[EventBehavior::EVENT_CHANGE_ENTITY_ORIGINAL_VALUES])) {
+                $eventEntityTransfer->setOriginalValues($data[EventBehavior::EVENT_CHANGE_ENTITY_ORIGINAL_VALUES]);
+            }
             if (isset($data[EventBehavior::EVENT_CHANGE_ENTITY_MODIFIED_COLUMNS])) {
                 $eventEntityTransfer->setModifiedColumns($data[EventBehavior::EVENT_CHANGE_ENTITY_MODIFIED_COLUMNS]);
             }


### PR DESCRIPTION
- Developer(s): @gechetspr

- Ticket: https://spryker.atlassian.net/browse/CC-3421

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/1269


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   EventBehavior         | patch                 |                       |

#### Release Notes

Fixed and issue with not triggered events.

-----------------------------------------

#### Module EventBehavior

##### Change log

Bugfixes

* Adjusted `TriggerManager::triggerEvents()` in order to not crash if `originalValue` index doesn't exist.

