### PR TITLE
Wrap Id querying in iterator class and add order by clause to prevent duplicates

### DIFF
--- a/src/Spryker/Zed/EventBehavior/Business/Model/EventPluginIdsIterator.php
+++ b/src/Spryker/Zed/EventBehavior/Business/Model/EventPluginIdsIterator.php
@@ -58,6 +58,7 @@ class EventPluginIdsIterator implements Iterator
             ->limit($this->chunkSize)
             ->where($this->plugin->getIdColumnName() . ModelCriteria::ISNOTNULL)
             ->select([$this->plugin->getIdColumnName()])
+            ->orderBy($this->plugin->getIdColumnName())
             ->find()
             ->getData();
     }

--- a/src/Spryker/Zed/EventBehavior/Business/Model/EventPluginIdsIterator.php
+++ b/src/Spryker/Zed/EventBehavior/Business/Model/EventPluginIdsIterator.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\EventBehavior\Business\Model;
+
+use Iterator;
+use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Spryker\Zed\EventBehavior\Dependency\Plugin\EventResourceQueryContainerPluginInterface;
+
+class EventPluginIdsIterator implements Iterator
+{
+    /**
+     * @var \Spryker\Zed\EventBehavior\Dependency\Plugin\EventResourceQueryContainerPluginInterface
+     */
+    private $plugin;
+
+    /**
+     * @var int
+     */
+    private $index = 0;
+
+    /**
+     * @var array
+     */
+    private $current = [];
+
+    /**
+     * @var int
+     */
+    private $chunkSize;
+
+    /**
+     * @var int
+     */
+    private $offset = 0;
+
+    /**
+     * @param \Spryker\Zed\EventBehavior\Dependency\Plugin\EventResourceQueryContainerPluginInterface $plugin
+     * @param int $chunkSize
+     */
+    public function __construct(EventResourceQueryContainerPluginInterface $plugin, int $chunkSize)
+    {
+        $this->plugin = $plugin;
+        $this->chunkSize = $chunkSize;
+    }
+
+    /**
+     * @return void
+     */
+    private function executeQuery(): void
+    {
+        $this->current = $this->plugin->queryData()
+            ->offset($this->offset)
+            ->limit($this->chunkSize)
+            ->where($this->plugin->getIdColumnName() . ModelCriteria::ISNOTNULL)
+            ->select([$this->plugin->getIdColumnName()])
+            ->find()
+            ->getData();
+    }
+
+    /**
+     * @return array
+     */
+    public function current(): array
+    {
+        return $this->current;
+    }
+
+    /**
+     * @return void
+     */
+    public function next(): void
+    {
+        $this->offset += $this->chunkSize;
+    }
+
+    /**
+     * @return int
+     */
+    public function key(): int
+    {
+        return $this->index;
+    }
+
+    /**
+     * @return bool
+     */
+    public function valid(): bool
+    {
+        if ($this->plugin->queryData()->count() === 0) {
+            return false;
+        }
+
+        $this->executeQuery();
+
+        return is_array($this->current) && count($this->current);
+    }
+
+    /**
+     * @return void
+     */
+    public function rewind(): void
+    {
+        $this->offset = 0;
+        $this->index = 0;
+        $this->current = [];
+    }
+}

--- a/src/Spryker/Zed/EventBehavior/Business/Model/EventResourceQueryContainerManager.php
+++ b/src/Spryker/Zed/EventBehavior/Business/Model/EventResourceQueryContainerManager.php
@@ -8,7 +8,6 @@
 namespace Spryker\Zed\EventBehavior\Business\Model;
 
 use Generated\Shared\Transfer\EventEntityTransfer;
-use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Spryker\Zed\EventBehavior\Dependency\Facade\EventBehaviorToEventInterface;
 use Spryker\Zed\EventBehavior\Dependency\Plugin\EventResourcePluginInterface;
 use Spryker\Zed\EventBehavior\Dependency\Plugin\EventResourceQueryContainerPluginInterface;
@@ -91,22 +90,9 @@ class EventResourceQueryContainerManager implements EventResourceManagerInterfac
      */
     protected function triggerEventsAll(EventResourceQueryContainerPluginInterface $plugin): void
     {
-        $query = $plugin->queryData();
-        $count = $query->count();
-        $loops = $count / $this->chunkSize;
-        $offset = 0;
-
-        for ($i = 0; $i < $loops; $i++) {
-            $ids = $plugin->queryData()
-                ->offset($offset)
-                ->limit($this->chunkSize)
-                ->where($plugin->getIdColumnName() . ModelCriteria::ISNOTNULL)
-                ->select([$plugin->getIdColumnName()])
-                ->find()
-                ->getData();
-
+        $eventPluginIdsIterator = new EventPluginIdsIterator($plugin, static::DEFAULT_CHUNK_SIZE);
+        foreach ($eventPluginIdsIterator as $ids) {
             $this->trigger($plugin, $ids);
-            $offset += $this->chunkSize;
         }
     }
 

--- a/src/Spryker/Zed/EventBehavior/Business/Model/EventResourceRepositoryManager.php
+++ b/src/Spryker/Zed/EventBehavior/Business/Model/EventResourceRepositoryManager.php
@@ -179,6 +179,7 @@ class EventResourceRepositoryManager implements EventResourceManagerInterface
     protected function getIdColumnName($plugin): ?string
     {
         $idColumnName = explode(static::DELIMITER, $plugin->getIdColumnName());
+
         return $idColumnName[1] ?? null;
     }
 

--- a/src/Spryker/Zed/EventBehavior/Business/Model/TriggerManager.php
+++ b/src/Spryker/Zed/EventBehavior/Business/Model/TriggerManager.php
@@ -80,6 +80,7 @@ class TriggerManager implements TriggerManagerInterface
             static::$eventBehaviorTableExists = true;
         } catch (PropelException | ConnectionException | EventBehaviorQueryNotExistsException $e) {
             static::$eventBehaviorTableExists = false;
+
             return;
         }
 

--- a/src/Spryker/Zed/EventBehavior/Persistence/Propel/Behavior/EventBehavior.php
+++ b/src/Spryker/Zed/EventBehavior/Persistence/Propel/Behavior/EventBehavior.php
@@ -585,6 +585,7 @@ protected function getOriginalValues(): array
 
         return array_reduce($this->getTable()->getColumns(), function ($columns, $columnObj) use ($tableName) {
             $columns[] = $this->formatFullColumnName($tableName, $columnObj->getName());
+
             return $columns;
         }, []);
     }
@@ -606,6 +607,7 @@ protected function getOriginalValues(): array
     public function addGetPhpType()
     {
         $tableMapPhpName = sprintf('%s%s', $this->getTable()->getPhpName(), 'TableMap');
+
         return "
 /**
  * @param string \$xmlValue

--- a/tests/SprykerTest/Zed/EventBehavior/Business/EventBehaviorFacadeTest.php
+++ b/tests/SprykerTest/Zed/EventBehavior/Business/EventBehaviorFacadeTest.php
@@ -437,6 +437,7 @@ class EventBehaviorFacadeTest extends Unit
                 ->will($this->returnCallback(function ($data) {
                     return json_decode($data, true);
                 }));
+
             return $utilEncodingMock;
         };
 


### PR DESCRIPTION
Because the for loop in `EventResourceQueryContainerManager::triggerEventsAll` blurs the responsibility of the class, this logic is outsourced into the EventPluginIdsIterator class.

Additionally i have added a `orderBy` clause to prevent selection of duplicate ids.