### PR TITLE
CC-5467 Fix exception running "console event:trigger" without a resource

### DIFF
--- a/src/Spryker/Zed/EventBehavior/Business/Model/EventResourcePluginResolver.php
+++ b/src/Spryker/Zed/EventBehavior/Business/Model/EventResourcePluginResolver.php
@@ -152,7 +152,11 @@ class EventResourcePluginResolver implements EventResourcePluginResolverInterfac
         foreach ($effectivePlugins as $effectiveEventPlugins) {
             $effectivePlugin = $this->resolveDuplicatePlugins($effectiveEventPlugins);
 
-            if ($effectivePlugin instanceof EventResourceRepositoryPluginInterface || $effectivePlugin instanceof EventResourceBulkRepositoryPluginInterface) {
+            if ($effectivePlugin === null) {
+                continue;
+            }
+
+            if ($this->isEventResourceRepositoryPlugin($effectivePlugin)) {
                 $pluginsPerExporter[static::REPOSITORY_EVENT_RESOURCE_PLUGINS][] = $effectivePlugin;
             }
 
@@ -176,11 +180,21 @@ class EventResourcePluginResolver implements EventResourcePluginResolverInterfac
         }
 
         foreach ($eventResourcePlugins as $eventResourcePlugin) {
-            if ($eventResourcePlugin instanceof EventResourceRepositoryPluginInterface || $eventResourcePlugin instanceof EventResourceBulkRepositoryPluginInterface) {
+            if ($this->isEventResourceRepositoryPlugin($eventResourcePlugin)) {
                 return $eventResourcePlugin;
             }
         }
 
         return current($eventResourcePlugins);
+    }
+
+    /**
+     * @param \Spryker\Zed\EventBehavior\Dependency\Plugin\EventResourcePluginInterface $eventResourcePlugin
+     *
+     * @return bool
+     */
+    protected function isEventResourceRepositoryPlugin(EventResourcePluginInterface $eventResourcePlugin): bool
+    {
+        return $eventResourcePlugin instanceof EventResourceRepositoryPluginInterface || $eventResourcePlugin instanceof EventResourceBulkRepositoryPluginInterface;
     }
 }


### PR DESCRIPTION
- Developer(s): @m7moud

- Ticket: https://spryker.atlassian.net/browse/CC-5467

- Academy PR: -

- Release Group: https://release.spryker.com/release-groups/view/1658


#### Please confirm

- [X] No new OS components - or they have been approved by legal department

#### Documentation

- [X] Functional documentation provided or in progress?
- [X] Integration guide for projects provided or not needed?
- [X] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   EventBehavior         | minor                 |                       |

#### Release Notes

Fixed an issue running `console event:trigger` without specifying a resource.

-----------------------------------------

#### Module EventBehavior

##### Change log

Improvements

- Adjusted and renamed `EventResourcePluginResolver::resolveDuplicatePlugins()` to resolve one dimensional array, instead of two dimensional array, returning the one plugin.
- Adjusted and renamed `EventResourcePluginResolver::mapPluginsByResourceName()` to map the event resource plugins by both resource and event.
- Adjusted and renamed `EventResourcePluginResolver::getEffectivePlugins()` to `filterPluginsByResources`.