### PR TITLE
TE-3900 Added new EventBehaviorEventDispatcherPlugin to replace Servi…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
   "require": {
     "php": ">=7.1",
     "spryker/event": "^2.4.0",
+    "spryker/event-dispatcher-extension": "^1.0.0",
     "spryker/kernel": "^3.30.0",
     "spryker/propel-orm": "^1.6.0",
     "spryker/symfony": "^3.1.0",
@@ -16,12 +17,16 @@
     "spryker/code-sniffer": "*",
     "spryker/config": "^3.1.0",
     "spryker/console": "^3.1.0 || ^4.0.0",
+    "spryker/container": "^1.4.0",
+    "spryker/event-dispatcher": "^1.0.0",
     "spryker/propel": "^3.0.0",
     "spryker/silex": "^2.0.0",
     "spryker/testify": "*"
   },
   "suggest": {
     "spryker/console": "*",
+    "spryker/container": "Install this module when you want to use the EventBehaviorEventDispatcherPlugin",
+    "spryker/event-dispatcher": "Install this module when you want to use the EventBehaviorEventDispatcherPlugin",
     "spryker/silex": "^2.0.0"
   },
   "autoload": {

--- a/src/Spryker/Zed/EventBehavior/Communication/Plugin/EventDispatcher/EventBehaviorEventDispatcherPlugin.php
+++ b/src/Spryker/Zed/EventBehavior/Communication/Plugin/EventDispatcher/EventBehaviorEventDispatcherPlugin.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\EventBehavior\Communication\Plugin\EventDispatcher;
+
+use Spryker\Service\Container\ContainerInterface;
+use Spryker\Shared\EventDispatcher\EventDispatcherInterface;
+use Spryker\Shared\EventDispatcherExtension\Dependency\Plugin\EventDispatcherPluginInterface;
+use Spryker\Zed\Kernel\Communication\AbstractPlugin;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @method \Spryker\Zed\EventBehavior\EventBehaviorConfig getConfig()
+ * @method \Spryker\Zed\EventBehavior\Persistence\EventBehaviorQueryContainerInterface getQueryContainer()
+ * @method \Spryker\Zed\EventBehavior\Business\EventBehaviorFacadeInterface getFacade()
+ * @method \Spryker\Zed\EventBehavior\Communication\EventBehaviorCommunicationFactory getFactory()
+ */
+class EventBehaviorEventDispatcherPlugin extends AbstractPlugin implements EventDispatcherPluginInterface
+{
+    /**
+     * @api
+     *
+     * @param \Spryker\Shared\EventDispatcher\EventDispatcherInterface $eventDispatcher
+     * @param \Spryker\Service\Container\ContainerInterface $container
+     *
+     * @return \Spryker\Shared\EventDispatcher\EventDispatcherInterface
+     */
+    public function extend(EventDispatcherInterface $eventDispatcher, ContainerInterface $container): EventDispatcherInterface
+    {
+        $eventDispatcher->addListener(KernelEvents::TERMINATE, function () {
+            $this->getFacade()->triggerRuntimeEvents();
+        });
+
+        return $eventDispatcher;
+    }
+}

--- a/src/Spryker/Zed/EventBehavior/Communication/Plugin/ServiceProvider/EventBehaviorServiceProvider.php
+++ b/src/Spryker/Zed/EventBehavior/Communication/Plugin/ServiceProvider/EventBehaviorServiceProvider.php
@@ -12,6 +12,8 @@ use Silex\ServiceProviderInterface;
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 
 /**
+ * @deprecated Use `\Spryker\Zed\EventBehavior\Communication\Plugin\EventDispatcher\EventBehaviorEventDispatcherPlugin` instead.
+ *
  * @method \Spryker\Zed\EventBehavior\Business\EventBehaviorFacadeInterface getFacade()
  * @method \Spryker\Zed\EventBehavior\EventBehaviorConfig getConfig()
  * @method \Spryker\Zed\EventBehavior\Persistence\EventBehaviorQueryContainerInterface getQueryContainer()


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-3900

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   EventBehavior         | minor                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module EventBehavior

##### Change log

Improvements

- Added new `\Spryker\Zed\EventBehavior\Communication\Plugin\EventDispatcher\EventBehaviorEventDispatcherPlugin` which triggers the expensive call to `EventBehaviorFacadeInterface::triggerRuntimeEvents()` after the response was send.
- Deprecated `EventBehaviorServiceProvider`.

