### PR TITLE
Use distinct query to prevent duplicate ids in result

### DIFF
--- a/src/Spryker/Zed/EventBehavior/Business/Model/EventResourceQueryContainerPluginIterator.php
+++ b/src/Spryker/Zed/EventBehavior/Business/Model/EventResourceQueryContainerPluginIterator.php
@@ -32,6 +32,7 @@ class EventResourceQueryContainerPluginIterator extends AbstractEventResourcePlu
     protected function updateCurrent(): void
     {
         $this->current = $this->plugin->queryData()
+            ->distinct()
             ->offset($this->offset)
             ->limit($this->chunkSize)
             ->where($this->plugin->getIdColumnName() . ModelCriteria::ISNOTNULL)


### PR DESCRIPTION
We were facing a problem when the events for each id in some cases would be triggered 2-10 times when running: `vendor/bin/console event:trigger -r [resource_name]`.

Using `->distinct()` in `EventResourceQueryContainerPluginIterator::updateCurrent` fixed this issue, as this will just return distinct ids.