### PR TITLE
TE-3485: P&S new structure

### DIFF
--- a/src/Spryker/Zed/EventBehavior/Business/EventBehaviorFacade.php
+++ b/src/Spryker/Zed/EventBehavior/Business/EventBehaviorFacade.php
@@ -119,12 +119,13 @@ class EventBehaviorFacade extends AbstractFacade implements EventBehaviorFacadeI
      *
      * @param array $resources
      * @param array $ids
+     * @param array $resourcePublisherPlugins
      *
      * @return void
      */
-    public function executeResolvedPluginsBySources(array $resources, array $ids = []): void
+    public function executeResolvedPluginsBySources(array $resources, array $ids = [], array $resourcePublisherPlugins = []): void
     {
-        $this->getFactory()->createEventResourcePluginResolver()->executeResolvedPluginsBySources($resources, $ids);
+        $this->getFactory()->createEventResourcePluginResolver()->executeResolvedPluginsBySources($resources, $ids, $resourcePublisherPlugins);
     }
 
     /**
@@ -132,11 +133,13 @@ class EventBehaviorFacade extends AbstractFacade implements EventBehaviorFacadeI
      *
      * @api
      *
+     * @param array $resourcePublisherPlugins
+     *
      * @return string[]
      */
-    public function getAvailableResourceNames(): array
+    public function getAvailableResourceNames(array $resourcePublisherPlugins = []): array
     {
-        return $this->getFactory()->createEventResourcePluginResolver()->getAvailableResourceNames();
+        return $this->getFactory()->createEventResourcePluginResolver()->getAvailableResourceNames($resourcePublisherPlugins);
     }
 
     /**

--- a/src/Spryker/Zed/EventBehavior/Business/EventBehaviorFacadeInterface.php
+++ b/src/Spryker/Zed/EventBehavior/Business/EventBehaviorFacadeInterface.php
@@ -106,10 +106,11 @@ interface EventBehaviorFacadeInterface
      *
      * @param array $resources
      * @param array $ids
+     * @param array $resourcePublisherPlugins
      *
      * @return void
      */
-    public function executeResolvedPluginsBySources(array $resources, array $ids = []): void;
+    public function executeResolvedPluginsBySources(array $resources, array $ids = [], array $resourcePublisherPlugins = []): void;
 
     /**
      * Specification:
@@ -117,9 +118,11 @@ interface EventBehaviorFacadeInterface
      *
      * @api
      *
+     * @param array $resourcePublisherPlugins
+     *
      * @return string[]
      */
-    public function getAvailableResourceNames(): array;
+    public function getAvailableResourceNames(array $resourcePublisherPlugins = []): array;
 
     /**
      * Specification:

--- a/src/Spryker/Zed/EventBehavior/Business/Model/EventResourcePluginResolver.php
+++ b/src/Spryker/Zed/EventBehavior/Business/Model/EventResourcePluginResolver.php
@@ -61,20 +61,23 @@ class EventResourcePluginResolver implements EventResourcePluginResolverInterfac
     /**
      * @param string[] $resources
      * @param int[] $ids
+     * @param array $resourcePublisherPlugins
      *
      * @return void
      */
-    public function executeResolvedPluginsBySources(array $resources, array $ids): void
+    public function executeResolvedPluginsBySources(array $resources, array $ids = [], array $resourcePublisherPlugins = []): void
     {
-        $pluginsPerExporter = $this->getResolvedPluginsByResources($resources);
+        $pluginsPerExporter = $this->getResolvedPluginsByResources($resources, $resourcePublisherPlugins);
 
         $this->processResourceEvents($pluginsPerExporter, $ids);
     }
 
     /**
+     * @param array $resourcePublisherPlugins
+     *
      * @return string[]
      */
-    public function getAvailableResourceNames(): array
+    public function getAvailableResourceNames(array $resourcePublisherPlugins = []): array
     {
         $resourceNames = [];
 
@@ -89,12 +92,13 @@ class EventResourcePluginResolver implements EventResourcePluginResolverInterfac
 
     /**
      * @param string[] $resources
+     * @param array $resourcePublisherPlugins
      *
      * @return array
      */
-    protected function getResolvedPluginsByResources(array $resources): array
+    protected function getResolvedPluginsByResources(array $resources, array $resourcePublisherPlugins = []): array
     {
-        $mappedEventResourcePlugin = $this->mapPluginsByResourceNameAndEvent();
+        $mappedEventResourcePlugin = $this->mapPluginsByResourceNameAndEvent($resourcePublisherPlugins);
         $effectivePluginsByResource = $this->filterPluginsByResources($mappedEventResourcePlugin, $resources);
         $pluginsPerExporter = [
             static::REPOSITORY_EVENT_RESOURCE_PLUGINS => [],
@@ -150,11 +154,18 @@ class EventResourcePluginResolver implements EventResourcePluginResolverInterfac
     }
 
     /**
+     * @param array $resourcePublisherPlugins
+     *
      * @return \Spryker\Zed\EventBehavior\Dependency\Plugin\EventResourcePluginInterface[][][]
      */
-    protected function mapPluginsByResourceNameAndEvent(): array
+    protected function mapPluginsByResourceNameAndEvent(array $resourcePublisherPlugins = []): array
     {
         $mappedEventResourcePlugin = [];
+
+        if ($resourcePublisherPlugins) {
+            $this->eventResourcePlugins = array_merge($this->eventResourcePlugins, $resourcePublisherPlugins);
+        }
+
         foreach ($this->eventResourcePlugins as $plugin) {
             $mappedEventResourcePlugin[$plugin->getResourceName()][$plugin->getEventName()][] = $plugin;
         }

--- a/src/Spryker/Zed/EventBehavior/Business/Model/EventResourcePluginResolverInterface.php
+++ b/src/Spryker/Zed/EventBehavior/Business/Model/EventResourcePluginResolverInterface.php
@@ -12,13 +12,16 @@ interface EventResourcePluginResolverInterface
     /**
      * @param string[] $resources
      * @param int[] $ids
+     * @param array $resourcePublisherPlugins
      *
      * @return void
      */
-    public function executeResolvedPluginsBySources(array $resources, array $ids): void;
+    public function executeResolvedPluginsBySources(array $resources, array $ids = [], array $resourcePublisherPlugins = []): void;
 
     /**
+     * @param array $resourcePublisherPlugins
+     *
      * @return string[]
      */
-    public function getAvailableResourceNames(): array;
+    public function getAvailableResourceNames(array $resourcePublisherPlugins = []): array;
 }

--- a/src/Spryker/Zed/EventBehavior/Communication/Console/EventTriggerConsole.php
+++ b/src/Spryker/Zed/EventBehavior/Communication/Console/EventTriggerConsole.php
@@ -14,6 +14,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
+ * @deprecated Use `Spryker\Zed\Publisher\Communication\Console\PublisherTriggerEventsConsole` instead.
+ *
  * @method \Spryker\Zed\EventBehavior\Business\EventBehaviorFacadeInterface getFacade()
  * @method \Spryker\Zed\EventBehavior\Persistence\EventBehaviorQueryContainerInterface getQueryContainer()
  * @method \Spryker\Zed\EventBehavior\Communication\EventBehaviorCommunicationFactory getFactory()

--- a/tests/SprykerTest/Zed/EventBehavior/Business/EventBehaviorFacadeTest.php
+++ b/tests/SprykerTest/Zed/EventBehavior/Business/EventBehaviorFacadeTest.php
@@ -357,7 +357,7 @@ class EventBehaviorFacadeTest extends Unit
     /**
      * @return \Spryker\Zed\EventBehavior\Dependency\Facade\EventBehaviorToEventInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function createEventFacadeMockBridge()
+    protected function createEventFacadeMockBridge(): EventBehaviorToEventInterface
     {
         return $this->getMockBuilder(EventBehaviorToEventInterface::class)
             ->disableOriginalConstructor()
@@ -372,7 +372,7 @@ class EventBehaviorFacadeTest extends Unit
     /**
      * @return \Spryker\Zed\EventBehavior\Dependency\Service\EventBehaviorToUtilEncodingInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function createUtilEncodingServiceBridge()
+    protected function createUtilEncodingServiceBridge(): EventBehaviorToUtilEncodingInterface
     {
         return $this->getMockBuilder(EventBehaviorToUtilEncodingInterface::class)
             ->disableOriginalConstructor()

--- a/tests/SprykerTest/Zed/EventBehavior/Business/Model/EventResourceQueryContainerManagerTest.php
+++ b/tests/SprykerTest/Zed/EventBehavior/Business/Model/EventResourceQueryContainerManagerTest.php
@@ -56,7 +56,7 @@ class EventResourceQueryContainerManagerTest extends Unit
     /**
      * @return \Spryker\Zed\EventBehavior\Dependency\Facade\EventBehaviorToEventInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function createEventFacadeMockBridge()
+    protected function createEventFacadeMockBridge(): EventBehaviorToEventInterface
     {
         return $this->getMockBuilder(EventBehaviorToEventInterface::class)
             ->disableOriginalConstructor()
@@ -71,7 +71,7 @@ class EventResourceQueryContainerManagerTest extends Unit
     /**
      * @return \Spryker\Zed\EventBehavior\Dependency\Plugin\EventResourceQueryContainerPluginInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function createEventResourceQueryContainerMockPlugin()
+    protected function createEventResourceQueryContainerMockPlugin(): EventResourceQueryContainerPluginInterface
     {
         return $this->getMockBuilder(EventResourceQueryContainerPluginInterface::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
- Developer(s): @alexanderM91 

- Ticket: https://spryker.atlassian.net/browse/TE-3485

- Suite nonsplit PR: spryker/suite-nonsplit#2194

- CORE PR: https://github.com/spryker/spryker/pull/5281

- RabbitMq PR: https://github.com/spryker/rabbit-mq/pull/48

- Release Group: https://release.spryker.com/release-groups/view/1414

- Release Overview: https://release.spryker.com/release/pull-request/4460

#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   EventBehavior       | minor                 |                         |

#### Release Notes

-----------------------------------------

#### Module EventBehavior

##### Change log

Improvements
- Adjusted `EventBehaviorFacadeInterface::executeResolvedPluginsBySources()` with an extra optional argument that contains an array of resource plugins.

Deprecations
  - Deprecated `Spryker\Zed\EventBehavior\Communication\Console\EventTriggerConsole`.


