### PR TITLE
TE-7001 Updated Symfony console commands to always return int.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "spryker/event-dispatcher-extension": "^1.0.0",
     "spryker/kernel": "^3.49.0",
     "spryker/propel-orm": "^1.6.0",
-    "spryker/symfony": "^3.1.0 || ^4.0.0",
+    "spryker/symfony": "^3.1.0",
     "spryker/util-encoding": "^2.1.0",
     "spryker/zend": "^2.1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "spryker/event-dispatcher-extension": "^1.0.0",
     "spryker/kernel": "^3.49.0",
     "spryker/propel-orm": "^1.6.0",
-    "spryker/symfony": "^3.1.0",
+    "spryker/symfony": "^3.1.0 || ^4.0.0",
     "spryker/util-encoding": "^2.1.0",
     "spryker/zend": "^2.1.0"
   },

--- a/src/Spryker/Zed/EventBehavior/Communication/Console/EventBehaviorTriggerTimeoutConsole.php
+++ b/src/Spryker/Zed/EventBehavior/Communication/Console/EventBehaviorTriggerTimeoutConsole.php
@@ -34,10 +34,12 @@ class EventBehaviorTriggerTimeoutConsole extends Console
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      *
-     * @return int|null|void
+     * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->getFacade()->triggerLostEvents();
+
+        return static::CODE_SUCCESS;
     }
 }

--- a/src/Spryker/Zed/EventBehavior/Communication/Console/EventTriggerConsole.php
+++ b/src/Spryker/Zed/EventBehavior/Communication/Console/EventTriggerConsole.php
@@ -36,10 +36,10 @@ class EventTriggerConsole extends Console
      */
     protected function configure(): void
     {
-        $this->addOption(static::RESOURCE_OPTION, static::RESOURCE_OPTION_SHORTCUT, InputArgument::OPTIONAL, 'Defines events of which resource(s) should be triggered, if there is more than one, use comma to separate them. 
+        $this->addOption(static::RESOURCE_OPTION, static::RESOURCE_OPTION_SHORTCUT, InputArgument::OPTIONAL, 'Defines events of which resource(s) should be triggered, if there is more than one, use comma to separate them.
         If not, full event triggering will be executed.');
 
-        $this->addOption(static::RESOURCE_IDS_OPTION, static::RESOURCE_IDS_OPTION_SHORTCUT, InputArgument::OPTIONAL, 'Defines ids of entities which should be triggered, if there is more than one, use comma to separate them. 
+        $this->addOption(static::RESOURCE_IDS_OPTION, static::RESOURCE_IDS_OPTION_SHORTCUT, InputArgument::OPTIONAL, 'Defines ids of entities which should be triggered, if there is more than one, use comma to separate them.
         If not, all ids triggering will be executed.');
 
         $this->setName(static::COMMAND_NAME)
@@ -52,9 +52,9 @@ class EventTriggerConsole extends Console
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      *
-     * @return int|null|void
+     * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $resources = [];
         $resourcesIds = [];

--- a/src/Spryker/Zed/EventBehavior/Communication/Console/EventTriggerListenerConsole.php
+++ b/src/Spryker/Zed/EventBehavior/Communication/Console/EventTriggerListenerConsole.php
@@ -64,9 +64,9 @@ class EventTriggerListenerConsole extends Console
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      *
-     * @return int|null|void
+     * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $listenerName = $input->getArgument(static::ARGUMENT_LISTENER_NAME);
         $transferData = $input->getArgument(static::ARGUMENT_DATA);
@@ -74,5 +74,7 @@ class EventTriggerListenerConsole extends Console
         $eventName = $input->getOption(static::OPTION_EVENT_NAME);
 
         $this->getFacade()->triggerEventListenerByName($listenerName, $transferData, $format, $eventName);
+
+        return static::CODE_SUCCESS;
     }
 }


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-7001

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/2897


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   EventBehavior         | minor                 |                       |

-----------------------------------------

#### Module EventBehavior

##### Change log

Improvements

- Always return `int` for console command.

