### PR TITLE
FRW-998 Dropped PHP 8.0 support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,12 @@ on:
 
 jobs:
   validation:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
         php-version: [
-            '8.0',
-            '8.1'
+            '8.2'
         ]
 
     steps:
@@ -86,12 +85,12 @@ jobs:
         run: composer cs-check
 
   prefer-lowest:
-      runs-on: ubuntu-18.04
+      runs-on: ubuntu-20.04
       strategy:
           fail-fast: false
           matrix:
               php-version: [
-                  '8.0'
+                  '8.1'
               ]
 
       steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [
+            '8.1',
             '8.2'
         ]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # EventBehavior Module
 [![CI](https://github.com/spryker/event-behavior/workflows/CI/badge.svg?branch=master)](https://github.com/spryker/event-behavior/actions?query=workflow%3ACI+branch%3Amaster)
 [![Latest Stable Version](https://poser.pugx.org/spryker/event-behavior/v/stable.svg)](https://packagist.org/packages/spryker/event-behavior)
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg)](https://php.net/)
 
 EventBehavior provides event-based propel behavior. By enabling this behavior in the Propel schema.xml, it will be able to add listeners to all events from the entities. Events could be of type create, update or delete.
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "EventBehavior module",
     "license": "proprietary",
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "spryker/event": "^2.4.0",
         "spryker/event-dispatcher-extension": "^1.0.0",
         "spryker/kernel": "^3.49.0",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -24,8 +24,8 @@
 
     <rule ref="Spryker.Internal.SprykerDisallowFunctions">
         <properties>
-            <!-- We want to prevent 8.0+ functions to break 7.4 compatibility -->
-            <property name="phpVersion" value="7.4"/>
+            <!-- We want to prevent 8.2+ functions to break 8.1 compatibility -->
+            <property name="phpVersion" value="8.1"/>
         </properties>
     </rule>
 

--- a/src/Spryker/Zed/EventBehavior/Communication/Console/EventBehaviorTriggerTimeoutConsole.php
+++ b/src/Spryker/Zed/EventBehavior/Communication/Console/EventBehaviorTriggerTimeoutConsole.php
@@ -31,7 +31,7 @@ class EventBehaviorTriggerTimeoutConsole extends Console
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName(static::COMMAND_NAME)
             ->setDescription(static::DESCRIPTION);

--- a/src/Spryker/Zed/EventBehavior/Communication/Console/EventTriggerListenerConsole.php
+++ b/src/Spryker/Zed/EventBehavior/Communication/Console/EventTriggerListenerConsole.php
@@ -63,7 +63,7 @@ class EventTriggerListenerConsole extends Console
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 

--- a/tests/SprykerTest/Zed/EventBehavior/_support/EventBehaviorBusinessTester.php
+++ b/tests/SprykerTest/Zed/EventBehavior/_support/EventBehaviorBusinessTester.php
@@ -21,7 +21,7 @@ use Codeception\Actor;
  * @method void comment($description)
  * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
  *
- * @SuppressWarnings(PHPMD)
+ * @SuppressWarnings(\PHPMD\PHPMD)
  */
 class EventBehaviorBusinessTester extends Actor
 {


### PR DESCRIPTION
- Developer(s): @asmarovydlo 

- Ticket: https://spryker.atlassian.net/browse/FRW-998

- Release Group: https://release.spryker.com/release-groups/view/5084

- PR Overview: https://release.spryker.com/release/pull-request-core/EventBehavior/87

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   EventBehavior             | minor          |                       |

-----------------------------------------

#### Module EventBehavior

##### Change log

Improvements 

- Added `PHP 8.2` support.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
