### PR TITLE
CC-33982: P&S optimisation.

### DIFF
--- a/src/Spryker/Shared/EventBehavior/EventBehaviorConstants.php
+++ b/src/Spryker/Shared/EventBehavior/EventBehaviorConstants.php
@@ -59,7 +59,7 @@ interface EventBehaviorConstants
      *
      * @api
      *
-     * @var int
+     * @var string
      */
-    public const MAX_RECOMMENDED_EVENT_MESSAGE_DATA_SIZE = 256;
+    public const MAX_RECOMMENDED_EVENT_MESSAGE_DATA_SIZE = 'MAX_RECOMMENDED_EVENT_MESSAGE_DATA_SIZE';
 }

--- a/src/Spryker/Shared/EventBehavior/EventBehaviorConstants.php
+++ b/src/Spryker/Shared/EventBehavior/EventBehaviorConstants.php
@@ -61,5 +61,5 @@ interface EventBehaviorConstants
      *
      * @var string
      */
-    public const MAX_EVENT_MESSAGE_DATA_SIZE = 'MAX_EVENT_MESSAGE_DATA_SIZE';
+    public const MAX_EVENT_MESSAGE_DATA_SIZE = 'EVENT_BEHAVIOR:MAX_EVENT_MESSAGE_DATA_SIZE';
 }

--- a/src/Spryker/Shared/EventBehavior/EventBehaviorConstants.php
+++ b/src/Spryker/Shared/EventBehavior/EventBehaviorConstants.php
@@ -51,4 +51,15 @@ interface EventBehaviorConstants
      * @var string
      */
     public const ENABLE_INSTANCE_POOLING = 'EVENT_BEHAVIOR:ENABLE_INSTANCE_POOLING';
+
+    /**
+     * Specification:
+     * - Recommended maximum data size for event messages in KB.
+     * - Used to log a warning if the event message data size exceeds this limit.
+     *
+     * @api
+     *
+     * @var int
+     */
+    public const MAX_RECOMMENDED_EVENT_MESSAGE_DATA_SIZE = 256;
 }

--- a/src/Spryker/Shared/EventBehavior/EventBehaviorConstants.php
+++ b/src/Spryker/Shared/EventBehavior/EventBehaviorConstants.php
@@ -61,5 +61,5 @@ interface EventBehaviorConstants
      *
      * @var string
      */
-    public const MAX_RECOMMENDED_EVENT_MESSAGE_DATA_SIZE = 'MAX_RECOMMENDED_EVENT_MESSAGE_DATA_SIZE';
+    public const MAX_EVENT_MESSAGE_DATA_SIZE = 'MAX_EVENT_MESSAGE_DATA_SIZE';
 }

--- a/src/Spryker/Zed/EventBehavior/EventBehaviorConfig.php
+++ b/src/Spryker/Zed/EventBehavior/EventBehaviorConfig.php
@@ -121,7 +121,7 @@ class EventBehaviorConfig extends AbstractBundleConfig
      *
      * @return int
      */
-    public function getMaxRecommendedEventMessageDataSize(): int
+    public function getMaxEventMessageDataSize(): int
     {
         return $this->get(EventBehaviorConstants::MAX_EVENT_MESSAGE_DATA_SIZE, 256);
     }

--- a/src/Spryker/Zed/EventBehavior/EventBehaviorConfig.php
+++ b/src/Spryker/Zed/EventBehavior/EventBehaviorConfig.php
@@ -123,6 +123,6 @@ class EventBehaviorConfig extends AbstractBundleConfig
      */
     public function getMaxRecommendedEventMessageDataSize(): int
     {
-        return $this->get(EventBehaviorConstants::MAX_RECOMMENDED_EVENT_MESSAGE_DATA_SIZE, 256);
+        return $this->get(EventBehaviorConstants::MAX_EVENT_MESSAGE_DATA_SIZE, 256);
     }
 }

--- a/src/Spryker/Zed/EventBehavior/EventBehaviorConfig.php
+++ b/src/Spryker/Zed/EventBehavior/EventBehaviorConfig.php
@@ -111,4 +111,18 @@ class EventBehaviorConfig extends AbstractBundleConfig
     {
         return static::$isEventDisabled;
     }
+
+    /**
+     * Specification:
+     * - Recommended maximum data size for event messages in KB.
+     * - Used to log a warning if the event message data size exceeds this limit.
+     *
+     * @api
+     *
+     * @return int
+     */
+    public function getMaxRecommendedEventMessageDataSize(): int
+    {
+        return $this->get(EventBehaviorConstants::MAX_RECOMMENDED_EVENT_MESSAGE_DATA_SIZE, 256);
+    }
 }

--- a/src/Spryker/Zed/EventBehavior/Persistence/Propel/Behavior/EventBehavior.php
+++ b/src/Spryker/Zed/EventBehavior/Persistence/Propel/Behavior/EventBehavior.php
@@ -435,10 +435,15 @@ protected function getForeignKeys()
  */
 protected function saveEventBehaviorEntityChange(array \$data)
 {
+    \$encodedData = json_encode(\$data);
+    if (strlen(\$encodedData) > 256 * 1024) {
+        \$this->log((\$data['event'] ?? '') . ' event message size exceeds the allowable limit of 256KB.', \\Propel\\Runtime\\Propel::LOG_WARNING);
+    }
+
     \$isInstancePoolingDisabledSuccessfully = \\Propel\\Runtime\\Propel::disableInstancePooling();
 
     \$spyEventBehaviorEntityChange = new \\Orm\\Zed\\EventBehavior\\Persistence\\SpyEventBehaviorEntityChange();
-    \$spyEventBehaviorEntityChange->setData(json_encode(\$data));
+    \$spyEventBehaviorEntityChange->setData(json_encode(\$encodedData));
     \$spyEventBehaviorEntityChange->setProcessId(\\Spryker\\Zed\\Kernel\\RequestIdentifier::getRequestId());
     \$spyEventBehaviorEntityChange->save();
 

--- a/src/Spryker/Zed/EventBehavior/Persistence/Propel/Behavior/EventBehavior.php
+++ b/src/Spryker/Zed/EventBehavior/Persistence/Propel/Behavior/EventBehavior.php
@@ -448,7 +448,7 @@ protected function saveEventBehaviorEntityChange(array \$data)
 
     if (\$dataLength > $maxRecommendedEventMessageDataSize * 1024) {
         \$warningMessage = sprintf(
-            '%s event message data size (%d KB) exceeds the allowable limit of %d KB.',
+            '%s event message data size (%d KB) exceeds the allowable limit of %d KB. Please reduce the event message size or it might disrupt P&S process.',
             (\$data['event'] ?? ''),
             \$dataLength / 1024,
             $maxRecommendedEventMessageDataSize,

--- a/src/Spryker/Zed/EventBehavior/Persistence/Propel/Behavior/EventBehavior.php
+++ b/src/Spryker/Zed/EventBehavior/Persistence/Propel/Behavior/EventBehavior.php
@@ -433,7 +433,7 @@ protected function getForeignKeys()
      */
     protected function addSaveEventBehaviorEntityChangeMethod()
     {
-        $maxRecommendedEventMessageDataSize = $this->getConfig()->getMaxRecommendedEventMessageDataSize();
+        $maxEventMessageDataSize = $this->getConfig()->getMaxEventMessageDataSize();
 
         return "
 /**
@@ -446,12 +446,12 @@ protected function saveEventBehaviorEntityChange(array \$data)
     \$encodedData = json_encode(\$data);
     \$dataLength = strlen(\$encodedData);
 
-    if (\$dataLength > $maxRecommendedEventMessageDataSize * 1024) {
+    if (\$dataLength > $maxEventMessageDataSize * 1024) {
         \$warningMessage = sprintf(
             '%s event message data size (%d KB) exceeds the allowable limit of %d KB. Please reduce the event message size or it might disrupt P&S process.',
             (\$data['event'] ?? ''),
             \$dataLength / 1024,
-            $maxRecommendedEventMessageDataSize,
+            $maxEventMessageDataSize,
         );
 
         \$this->log(\$warningMessage, \\Propel\\Runtime\\Propel::LOG_WARNING);

--- a/src/Spryker/Zed/EventBehavior/Persistence/Propel/Behavior/EventBehavior.php
+++ b/src/Spryker/Zed/EventBehavior/Persistence/Propel/Behavior/EventBehavior.php
@@ -443,7 +443,7 @@ protected function saveEventBehaviorEntityChange(array \$data)
     \$isInstancePoolingDisabledSuccessfully = \\Propel\\Runtime\\Propel::disableInstancePooling();
 
     \$spyEventBehaviorEntityChange = new \\Orm\\Zed\\EventBehavior\\Persistence\\SpyEventBehaviorEntityChange();
-    \$spyEventBehaviorEntityChange->setData(json_encode(\$encodedData));
+    \$spyEventBehaviorEntityChange->setData(\$encodedData);
     \$spyEventBehaviorEntityChange->setProcessId(\\Spryker\\Zed\\Kernel\\RequestIdentifier::getRequestId());
     \$spyEventBehaviorEntityChange->save();
 


### PR DESCRIPTION
- Developer(s): @dmiseev

- Ticket: https://spryker.atlassian.net/browse/CC-33982

- Release Group: https://release.spryker.com/release-groups/view/5485

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   EventBehavior        | minor                 |                       |

-----------------------------------------

#### Module EventBehavior

##### Change log

Improvements

- Introduced `EventBehaviorConstants::MAX_EVENT_MESSAGE_DATA_SIZE` to define the recommended maximum data size for event messages (in KB).
- Introduced `EventBehaviorConfig::getMaxEventMessageDataSize()` method.
- Adjusted `EventBehavior::saveEventBehaviorEntityChange()` to log a warning messages when event message data size exceeds the limit defined by EventBehaviorConfig::getMaxEventMessageDataSize().

