### PR TITLE
SUPESC-946 Fixed events deletion by process id when there are no even…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           echo "::set-output name=dir::$(composer config cache-files-dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -120,7 +120,7 @@ jobs:
             run: |
                 echo "::set-output name=dir::$(composer config cache-files-dir)"
 
-          - uses: actions/cache@v2
+          - uses: actions/cache@v3
             with:
                 path: ${{ steps.composer-cache.outputs.dir }}
                 key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/src/Spryker/Zed/EventBehavior/Business/Model/TriggerManager.php
+++ b/src/Spryker/Zed/EventBehavior/Business/Model/TriggerManager.php
@@ -127,7 +127,7 @@ class TriggerManager implements TriggerManagerInterface
             $offset += $limit;
         } while ($countEvents === $limit);
 
-        if ($countEvents === $triggeredEvents) {
+        if ($countEvents === $triggeredEvents && $triggeredEvents > 0) {
             $this->eventBehaviorEntityManager->deleteEventBehaviorEntityByProcessId($processId);
 
             return;

--- a/src/Spryker/Zed/EventBehavior/Persistence/Propel/Behavior/EventBehavior.php
+++ b/src/Spryker/Zed/EventBehavior/Persistence/Propel/Behavior/EventBehavior.php
@@ -105,33 +105,27 @@ if (\$affectedRows) {
     {
         $parameter = array_change_key_case($parameter, CASE_LOWER);
 
-        // @phpstan-ignore-next-line
         $this->parameters[$parameter['name']] = [];
 
         if (!isset($parameter['column'])) {
             throw new PropelException(sprintf('"column" attribute for %s event behavior is missing', $parameter['name']));
         }
 
-        // @phpstan-ignore-next-line
         $this->parameters[$parameter['name']]['column'] = $parameter['column'];
 
         if (isset($parameter['value'])) {
-            // @phpstan-ignore-next-line
             $this->parameters[$parameter['name']]['value'] = $parameter['value'];
         }
 
         if (isset($parameter['operator'])) {
-            // @phpstan-ignore-next-line
             $this->parameters[$parameter['name']]['operator'] = $parameter['operator'];
         }
 
         if (isset($parameter['keep-original'])) {
-            // @phpstan-ignore-next-line
             $this->parameters[$parameter['name']]['keep-original'] = $parameter['keep-original'];
         }
 
         if (isset($parameter['keep-additional'])) {
-            // @phpstan-ignore-next-line
             $this->parameters[$parameter['name']]['keep-additional'] = $parameter['keep-additional'];
         }
     }


### PR DESCRIPTION
- Developer(s): @limeeugenia

- Ticket: https://spryker.atlassian.net/browse/SUPESC-946

- Release Group: https://release.spryker.com/release-groups/view/5773

- Suite-nonsplit (bc-check-only): https://github.com/spryker/suite-nonsplit/pull/9439

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   EventBehavior         | patch                 |                       |

-----------------------------------------

#### Module EventBehavior

##### Change log

Fixes

- Adjusted `EventBehaviorFacade::triggerRuntimeEvents()` to not trigger delete on `spy_event_behavior_entity_change` table when no events were triggered.

