### PR TITLE
SOL-542 RabbitMQ Memory Issue

### DIFF
--- a/src/Spryker/Shared/EventBehavior/EventBehaviorConstants.php
+++ b/src/Spryker/Shared/EventBehavior/EventBehaviorConstants.php
@@ -62,4 +62,15 @@ interface EventBehaviorConstants
      * @var string
      */
     public const MAX_EVENT_MESSAGE_DATA_SIZE = 'EVENT_BEHAVIOR:MAX_EVENT_MESSAGE_DATA_SIZE';
+
+    /**
+     * Specification:
+     * - Sleep duration in seconds between publish:trigger-events iterator chunks.
+     * - Set to 0 to disable throttling.
+     *
+     * @api
+     *
+     * @var string
+     */
+    public const TRIGGER_CHUNK_SLEEP_SECONDS = 'EVENT_BEHAVIOR:TRIGGER_CHUNK_SLEEP_SECONDS';
 }

--- a/src/Spryker/Zed/EventBehavior/Business/EventBehaviorBusinessFactory.php
+++ b/src/Spryker/Zed/EventBehavior/Business/EventBehaviorBusinessFactory.php
@@ -59,8 +59,7 @@ class EventBehaviorBusinessFactory extends AbstractBusinessFactory
     {
         return new EventResourceQueryContainerManager(
             $this->getEventFacade(),
-            $this->getConfig()->getChunkSize(),
-            $this->getConfig()->getTriggerChunkSleepSeconds(),
+            $this->getConfig()
         );
     }
 

--- a/src/Spryker/Zed/EventBehavior/Business/EventBehaviorBusinessFactory.php
+++ b/src/Spryker/Zed/EventBehavior/Business/EventBehaviorBusinessFactory.php
@@ -60,6 +60,7 @@ class EventBehaviorBusinessFactory extends AbstractBusinessFactory
         return new EventResourceQueryContainerManager(
             $this->getEventFacade(),
             $this->getConfig()->getChunkSize(),
+            $this->getConfig()->getTriggerChunkSleepSeconds(),
         );
     }
 

--- a/src/Spryker/Zed/EventBehavior/Business/Model/EventResourceQueryContainerManager.php
+++ b/src/Spryker/Zed/EventBehavior/Business/Model/EventResourceQueryContainerManager.php
@@ -11,6 +11,7 @@ use Generated\Shared\Transfer\EventEntityTransfer;
 use Iterator;
 use Spryker\Zed\EventBehavior\Dependency\Facade\EventBehaviorToEventInterface;
 use Spryker\Zed\EventBehavior\Dependency\Plugin\EventResourceQueryContainerPluginInterface;
+use Spryker\Zed\EventBehavior\EventBehaviorConfig;
 
 class EventResourceQueryContainerManager implements EventResourceManagerInterface
 {
@@ -41,12 +42,11 @@ class EventResourceQueryContainerManager implements EventResourceManagerInterfac
      */
     public function __construct(
         EventBehaviorToEventInterface $eventFacade,
-        ?int $chunkSize = null,
-        int $chunkSleepSeconds = null,
+        EventBehaviorConfig $config
     ) {
         $this->eventFacade = $eventFacade;
-        $this->chunkSize = $chunkSize ?? static::DEFAULT_CHUNK_SIZE;
-        $this->chunkSleepSeconds = $chunkSleepSeconds;
+        $this->chunkSize = $config->getChunkSize() ?? static::DEFAULT_CHUNK_SIZE;
+        $this->chunkSleepSeconds = $config->getTriggerChunkSleepSeconds();
     }
 
     /**

--- a/src/Spryker/Zed/EventBehavior/Business/Model/EventResourceQueryContainerManager.php
+++ b/src/Spryker/Zed/EventBehavior/Business/Model/EventResourceQueryContainerManager.php
@@ -42,7 +42,7 @@ class EventResourceQueryContainerManager implements EventResourceManagerInterfac
     public function __construct(
         EventBehaviorToEventInterface $eventFacade,
         ?int $chunkSize = null,
-        int $chunkSleepSeconds = 3
+        int $chunkSleepSeconds = null,
     ) {
         $this->eventFacade = $eventFacade;
         $this->chunkSize = $chunkSize ?? static::DEFAULT_CHUNK_SIZE;

--- a/src/Spryker/Zed/EventBehavior/Business/Model/EventResourceQueryContainerManager.php
+++ b/src/Spryker/Zed/EventBehavior/Business/Model/EventResourceQueryContainerManager.php
@@ -30,15 +30,23 @@ class EventResourceQueryContainerManager implements EventResourceManagerInterfac
     protected $chunkSize;
 
     /**
+     * @var int
+     */
+    protected $chunkSleepSeconds;
+
+    /**
      * @param \Spryker\Zed\EventBehavior\Dependency\Facade\EventBehaviorToEventInterface $eventFacade
      * @param int|null $chunkSize
+     * @param int $chunkSleepSeconds
      */
     public function __construct(
         EventBehaviorToEventInterface $eventFacade,
-        ?int $chunkSize = null
+        ?int $chunkSize = null,
+        int $chunkSleepSeconds = 3
     ) {
         $this->eventFacade = $eventFacade;
         $this->chunkSize = $chunkSize ?? static::DEFAULT_CHUNK_SIZE;
+        $this->chunkSleepSeconds = $chunkSleepSeconds;
     }
 
     /**
@@ -94,9 +102,27 @@ class EventResourceQueryContainerManager implements EventResourceManagerInterfac
      */
     protected function processEventsByPluginItreator(EventResourceQueryContainerPluginInterface $plugin): void
     {
-        foreach ($this->createEventResourceQueryContainerPluginIterator($plugin) as $ids) {
+        $iterator = $this->createEventResourceQueryContainerPluginIterator($plugin);
+        $iterator->rewind();
+
+        while ($iterator->valid()) {
+            $ids = $iterator->current();
             $this->triggerBulk($plugin, $ids);
+
+            $iterator->next();
+            if ($iterator->valid()) {
+                $this->wait();
+            }
         }
+    }
+
+    protected function wait(): void
+    {
+        if ($this->chunkSleepSeconds <= 0) {
+            return;
+        }
+
+        sleep($this->chunkSleepSeconds);
     }
 
     /**

--- a/src/Spryker/Zed/EventBehavior/EventBehaviorConfig.php
+++ b/src/Spryker/Zed/EventBehavior/EventBehaviorConfig.php
@@ -27,6 +27,8 @@ class EventBehaviorConfig extends AbstractBundleConfig
      */
     protected const DEFUALT_TRIGGER_CHUNK_SIZE = 1000;
 
+    protected const int DEFAULT_TRIGGER_CHUNK_SLEEP_SECONDS = 5;
+
     /**
      * @var bool
      */
@@ -124,5 +126,15 @@ class EventBehaviorConfig extends AbstractBundleConfig
     public function getMaxEventMessageDataSize(): int
     {
         return $this->get(EventBehaviorConstants::MAX_EVENT_MESSAGE_DATA_SIZE, 256);
+    }
+
+    /**
+     * @api
+     *
+     * @return int
+     */
+    public function getTriggerChunkSleepSeconds(): int
+    {
+        return $this->get(EventBehaviorConstants::TRIGGER_CHUNK_SLEEP_SECONDS, static::DEFAULT_TRIGGER_CHUNK_SLEEP_SECONDS);
     }
 }


### PR DESCRIPTION
## PR Description
Add a meaningful description here that will let us know what you want to fix with this PR or what functionality you want to add.

#### Release Table

Module                    | Release Type         | Constraint Updates         |
:------------------------ | :------------------- | :------------------------- |
EventBehavior            | minor                |                  |

-----------------------------------------

#### Module EventBehavior

##### Change log

Improvements
- Introduced `Spryker/Shared/EventBehavior/EventBehaviorConstants::TRIGGER_CHUNK_SLEEP_SECONDS` to allow configuring a sleep interval between chunk iterations of the `publish:trigger-events` command. This prevents RabbitMQ from being overwhelmed during republishing of large datasets.

